### PR TITLE
Fixing compilation errors, adding README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# artin_code
+
+Compile with `g++ artin_code.cpp -o artin_code`. After compilation, run with `./artin_code` 

--- a/artin_code.cpp
+++ b/artin_code.cpp
@@ -1,5 +1,3 @@
-artin_code
-
 #include <iostream>
 #include <vector>
 #include <bitset>
@@ -11,8 +9,8 @@ artin_code
 using namespace std;
 
 typedef long long ll;
-typedef pair pii;
-typedef vector vi;
+// typedef pair pii;
+// typedef vector vi;
 typedef long double ld;
 
 const ll N = 1e8 + 5;
@@ -204,7 +202,7 @@ inline ld get_six(ll a) {
     return A;
 }
 
-unordered_map f_vals; //A bit of caching, probably doesn't matter.
+unordered_map<ll, ld> f_vals; //A bit of caching, probably doesn't matter.
 ll HC = 1e9;
 
 ld get_dens(ll a, ll b) {


### PR DESCRIPTION
Using the basic command line `g++ artin_code.cpp`, I received the following errors:

```
artin_code.cpp:1:1: error: unknown type name 'artin_code'
    1 | artin_code
      | ^
In file included from artin_code.cpp:3:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/iostream:43:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/ios:223:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__locale:15:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/shared_ptr.h:14:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__compare/compare_three_way.h:13:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__compare/three_way_comparable.h:12:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__compare/common_comparison_category.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cstddef:40:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_integral.h:38:29: error: redefinition of '__libcpp_is_integral<int>'
   38 | template <>          struct __libcpp_is_integral<int>                { enum { value = 1 }; };
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_integral.h:34:29: note: previous definition is here
   34 | template <>          struct __libcpp_is_integral<char16_t>           { enum { value = 1 }; };
      |                             ^
In file included from artin_code.cpp:3:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/iostream:43:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/ios:223:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__locale:15:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/shared_ptr.h:33:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:17:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__functional/hash.h:398:29: error: redefinition of 'hash<int>'
  398 | struct _LIBCPP_TEMPLATE_VIS hash<int> : public __unary_function<int, size_t> {
      |                             ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__functional/hash.h:371:29: note: previous definition is here
  371 | struct _LIBCPP_TEMPLATE_VIS hash<char16_t> : public __unary_function<char16_t, size_t> {
      |                             ^
artin_code.cpp:14:9: error: use of class template 'pair' requires template arguments
   14 | typedef pair pii;
      |         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__utility/pair.h:80:29: note: template is declared here
   79 | template <class _T1, class _T2>
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   80 | struct _LIBCPP_TEMPLATE_VIS pair
      |                             ^
artin_code.cpp:15:9: error: unknown type name 'vector'; did you mean 'hecto'?
   15 | typedef vector vi;
      |         ^~~~~~
      |         hecto
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/ratio:278:28: note: 'hecto' declared here
  278 | typedef ratio< 100LL, 1LL> hecto;
      |                            ^
artin_code.cpp:207:1: error: use of class template 'unordered_map' requires template arguments
  207 | unordered_map f_vals; //A bit of caching, probably doesn't matter.
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/unordered_map:1029:28: note: template is declared here
 1024 | template <class _Key,
      | ~~~~~~~~~~~~~~~~~~~~~
 1025 |           class _Tp,
      |           ~~~~~~~~~~
 1026 |           class _Hash  = hash<_Key>,
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
 1027 |           class _Pred  = equal_to<_Key>,
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1028 |           class _Alloc = allocator<pair<const _Key, _Tp> > >
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1029 | class _LIBCPP_TEMPLATE_VIS unordered_map {
      |                            ^
6 errors generated.
```

I attempted to compile this file with `g++` on macOS 15.0 (24A335). `g++` returned the following version information.

```
$ g++ -v
Apple clang version 16.0.0 (clang-1600.0.26.3)
Target: x86_64-apple-darwin24.0.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

This pull request attempts to fix the above errors. It removes the initial `artin_code` line at the beginning of the file, which I believe is possibly just a syntax error? It comments out the seemingly-unused `pii` and `vii` typedefs, as they were producing missing template argument errors above. It adds template arguments to the `unordered_map` `f_vals`, mapping from `long long` to `long double`. I'm not certain these are the correct types for this map, so reviewers should check this with special care. Finally, it adds a README explaining steps for compiling and running the program.

After these modifications, I was able to compile and run the program successfully. I confirmed  the program's execution up to the time-consuming main loop, but didn't get to see the main loop complete and produce the final answer even after running for a couple hours. A reviewer should confirm that the program still completes successfully and produces the correct answer after these modifications.